### PR TITLE
Update scikit-learn to v0.24

### DIFF
--- a/geosketch/__init__.py
+++ b/geosketch/__init__.py
@@ -1,3 +1,3 @@
 from .sketch import *
 
-__version__ = '1.1'
+__version__ = '1.2'

--- a/geosketch/kmeanspp.py
+++ b/geosketch/kmeanspp.py
@@ -1,4 +1,4 @@
-from sklearn.cluster.k_means_ import *
+from sklearn.cluster._kmeans import *
 
 def kmeanspp(X, n_clusters, seed=None, replace=False,
              n_local_trials=1):

--- a/geosketch/sketch.py
+++ b/geosketch/sketch.py
@@ -488,7 +488,7 @@ def louvain3(X, N, seed=None, replace=False):
 
 def louvain(X, N, resolution=1, seed=None, replace=False):
     from anndata import AnnData
-    import scanpy.api as sc
+    import scanpy as sc
 
     adata = AnnData(X=X)
     sc.pp.neighbors(adata, use_rep='X')

--- a/geosketch/utils.py
+++ b/geosketch/utils.py
@@ -29,7 +29,7 @@ def reduce_dimensionality(X, method='svd', dimred=DIMRED, raw=False):
         highest_disp_idx = np.argsort(disp)[::-1][:dimred]
         return X[:, highest_disp_idx].toarray()
     else:
-        sys.stderr.write('ERROR: Unknown method {}.'.format(svd))
+        sys.stderr.write('ERROR: Unknown method {}.'.format(method))
         exit(1)
 
 def dispersion(X, eps=1e-10):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='geosketch',
-    version='1.1',
+    version='1.2',
     description='Geometry-preserving random sampling',
     url='https://github.com/brianhie/geosketch',
     download_url='https://github.com/brianhie/geosketch/archive/v1.1.tar.gz',
@@ -10,7 +10,7 @@ setup(
     install_requires=[
         'fbpca>=1.0',
         'numpy>=1.12.0',
-        'scikit-learn>=0.20rc1',
+        'scikit-learn>=0.24',
     ],
     author='Brian Hie',
     author_email='brianhie@mit.edu',


### PR DESCRIPTION
**Main change: Updated scikit-learn dependency to v0.24.** 

In v0.24 [`sklearn.cluster.k_means_`](https://github.com/scikit-learn/scikit-learn/blob/0.21.X/sklearn/cluster/k_means_.py) was deprecated so it's been changed to [`sklearn.cluster._kmeans`](https://github.com/scikit-learn/scikit-learn/blob/0.24.X/sklearn/cluster/_kmeans.py) in `kmeanspp.py`. The idea behind that is that it would be useful for this package not to have an old dependency on `scikit-learn<=0.22`.

Additional minor fixes: 
- fixed method name in `reduce_dimensionality` error message
- removed old `scanpy.api` interface in favor of just `scanpy`
- bumped geosketch version to `1.2`

Disclaimer: didn't find any test to run on the package, so you may want to double check the new ouptus.